### PR TITLE
fix: display album art for local songs in widget

### DIFF
--- a/app/src/main/kotlin/iad1tya/echo/music/widget/MusicWidgetProvider.kt
+++ b/app/src/main/kotlin/iad1tya/echo/music/widget/MusicWidgetProvider.kt
@@ -235,16 +235,26 @@ class MusicWidgetProvider : AppWidgetProvider() {
                     try {
                         android.util.Log.d("MusicWidget", "Loading album art from: $albumArtUrl")
                         
-                        // Download image from URL
-                        val url = URL(albumArtUrl)
-                        val connection = url.openConnection()
-                        connection.connectTimeout = 5000
-                        connection.readTimeout = 5000
-                        connection.connect()
+                        // Handle both content:// URIs (local files) and http(s):// URLs
+                        val inputStream = when {
+                            albumArtUrl.startsWith("content://") -> {
+                                // Use ContentResolver for content URIs (local files)
+                                val uri = android.net.Uri.parse(albumArtUrl)
+                                context.contentResolver.openInputStream(uri)
+                            }
+                            albumArtUrl.startsWith("http://") || albumArtUrl.startsWith("https://") -> {
+                                // Use URL connection for remote images
+                                val url = URL(albumArtUrl)
+                                val connection = url.openConnection()
+                                connection.connectTimeout = 5000
+                                connection.readTimeout = 5000
+                                connection.connect()
+                                connection.getInputStream()
+                            }
+                            else -> null
+                        }
                         
-                        val inputStream = connection.getInputStream()
-                        val bitmap = BitmapFactory.decodeStream(inputStream)
-                        inputStream.close()
+                        val bitmap = inputStream?.use { BitmapFactory.decodeStream(it) }
                         
                         if (bitmap != null) {
                             android.util.Log.d("MusicWidget", "Bitmap loaded successfully: ${bitmap.width}x${bitmap.height}")


### PR DESCRIPTION
- Handle content:// URIs for local album art in MusicWidgetProvider
- Fallback to http(s) URLs for remote images
- Fix issue where widget showed no art for local media

Fixes #202

## 📋 Pull Request Description
Brief description of the changes made in this PR - > 
# Changes Made
- Updated `MusicWidgetProvider.kt` to detect the URI scheme of the album art.
- Added logic to handle `content://` URIs (used by Android MediaStore for local files) using `ContentResolver`.
- Maintained existing logic for `http://` and `https://` URLs for remote images.
- Improved resource management by using `.use {}` blocks for stream handling.

## 🔄 Type of Change
- [⚫] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other: _______________

## 🎯 Related Issues
Fixes #202 
Closes #none

## 📱 Testing
- [⚫] I have tested these changes locally
- [⚫] I have tested on different devices/Android versions
- [⚫] I have tested both FOSS and Full build variants
- [⚫] I have verified the app builds successfully

## 📸 Screenshots
If applicable, add screenshots to show the changes.

## 📋 Checklist
- [⚫] My code follows the project's style guidelines
- [⚫] I have performed a self-review of my code
- [⚫] I have commented my code, particularly in hard-to-understand areas
- [⚫] I have made corresponding changes to the documentation
- [⚫] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [⚫] New and existing unit tests pass locally with my changes
- [⚫] Any dependent changes have been merged and published

## 🔍 Additional Notes
Any additional information about the PR.
## 🔄 How to Test
1. Ensure you have local MP3 files with embedded album art on your device/emulator.
2. Install the app and grant storage permissions.
3. Play a **local song**.
4. Add the **Echo Music Widget** to your home screen (or refresh it if already present).
5. **Verify:** The widget should now correctly display the album art of the local song.
6. (Optional) Play an online song to ensure remote images still work.

conclusion :
Tested on local build with local MP3 files. Verified widget updates correctly with album art for both local and remote sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved music widget album art loading with enhanced support for various image sources.
  * Optimized resource management for image loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->